### PR TITLE
Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,17 @@
 .packages
 .pub/
 
+flutter_code_input.iml
+flutter_code_input_android.iml
+
 build/
+android/
+ios/
 ios/.generated/
 ios/Flutter/Generated.xcconfig
 ios/Runner/GeneratedPluginRegistrant.*
+
+.metadata
+launch.json
+*.lock
+*.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## [1.0.0] - Stable release
 
 * Full rewrite of the library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
-## [0.0.1] - TODO: Add release date.
+## [1.0.0] - Stable release
 
-* TODO: Describe initial release.
+* Full rewrite of the library.
+* You can provide a custom builder to build the character entities.
+* Provided a wide range of pre-build builders to use (circles or rectangles to be used in light or dark mode).
+* Example added.
+* Readme edited. Installtion does _not_ have to be described there, that's what pub's "Install" tab is for.
+* License added.
+
+## [0.0.1] - Initial release
+
+* Initial release.

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,19 @@
-TODO: Add your license here.
+Copyright (c) 2018 Marcel Garus & Rahiche
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,48 @@
 # code_input
 
-Code input widget : segmented code input control
+A Flutter widget for inputting content with a fixed length, visually treating each character as a separate segment.
 
+- [Pub Package](https://pub.dartlang.org/packages/code_input)
+- [GitHub Repository](https://github.com/rahiche/flutter_code_input)
+- [API reference](https://pub.dartlang.org/documentation/code_input/)
 
-## install it
+## Usage
 
+This is a small example:
+
+```dart
+CodeInput(
+  length: 4,
+  keyboardType: TextInputType.number,
+  builder: CodeInputBuilders.lightCircle(),
+  onFilled: (value) => print('Your input is $value.'),
+)
 ```
-dependencies:
-  code_input: ^0.0.2
-```
-
-## import it
-
-```
-import 'package:code_input/code_input.dart';
-```
-
-## This is the Widget
 
 <img src="https://i.imgur.com/en5C9HZ.gif" width="200"/>
 
+For more information about the properties, have a look at the [API reference](https://pub.dartlang.org/documentation/code_input/).
 
-## Example
+## LICENSE
 
+```legal
+Copyright (c) 2018 Marcel Garus & Rahiche
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
-return Scaffold(
-  appBar: AppBar(
-    title: Text("Code Input"),
-  ),
-  body: Center(
-    child: CodeInput(
-      //how many input widget you want  
-      length: 5,
-    ),
-  ),
-);
-```
-
-
-
-For help getting started with Flutter, view our online [documentation](https://flutter.io/).
-
-For help on editing package code, view the [documentation](https://flutter.io/developing-packages/).

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:code_input/code_input.dart';
+
+void main() => runApp(MyApp());
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Code input',
+      color: Colors.deepOrange,
+      home: Scaffold(
+        backgroundColor: Colors.deepOrange,
+        body: Center(child: _buildCodeInput())
+      ),
+    );
+  }
+
+  Widget _buildCodeInput() {
+    return CodeInput(
+      length: 4,
+      keyboardType: TextInputType.number,
+      builder: CodeInputBuilders.lightCircle(),
+      onFilled: (value) => print('Your input is $value.'),
+    );
+  }
+}

--- a/lib/code_input.dart
+++ b/lib/code_input.dart
@@ -3,152 +3,385 @@ library code_input;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-
-//this is just a dummy implementation to help someone in SO
-// i will make it better in the future 
+/// A widget for inputting content with a fixed length, visually treating each
+/// character as a separate segment.
+/// 
+/// ## Sample code
+/// 
+/// ```dart
+/// CodeInput(
+///   length: 4,
+///   keyboardType: TextInputType.number,
+///   builder: CodeInputBuilders.lightCircle(),
+///   onFilled: (value) => print('Your input is $value.'),
+/// )
+/// ```
+/// 
+/// See also:
+/// 
+/// * [TextField], an input where the characters aren't separated from each
+///   other.
+typedef CodeInputBuilder = Widget Function(bool hasFocus, String char);
 
 class CodeInput extends StatefulWidget {
+  const CodeInput._({
+    Key key,
+    @required this.length,
+    @required this.keyboardType,
+    @required this.inputFormatters,
+    @required this.builder,
+    this.onChanged,
+    this.onFilled,
+  }) : super(key: key);
+
+  factory CodeInput({
+    Key key,
+    @required int length,
+    TextInputType keyboardType = TextInputType.text,
+    List<TextInputFormatter> inputFormatters,
+    @required CodeInputBuilder builder,
+    void Function(String value) onChanged,
+    void Function(String value) onFilled,
+  }) {
+    assert(length != null);
+    assert(length > 0, 'The length needs to be larger than zero.');
+    assert(length.isFinite, 'The length needs to be finite.');
+    assert(keyboardType != null);
+    assert(builder != null, 
+      'The builder is required for rendering the character segments.'
+    );
+
+    inputFormatters ??= _createInputFormatters(length, keyboardType);
+
+    return CodeInput._(
+      key: key,
+      length: length,
+      keyboardType: keyboardType,
+      inputFormatters: inputFormatters,
+      builder: builder,
+      onChanged: onChanged,
+      onFilled: onFilled,
+    );
+  }
+
+  /// The length of character entities to always display.
+  /// 
+  /// ## Sample code
+  /// 
+  /// A code input with 4 characters:
+  /// 
+  /// ```dart
+  /// CodeInput(length: 4)
+  /// ```
   final int length;
 
-  const CodeInput({Key key, this.length}) : super(key: key);
+  /// The type of thconstard which shows up.
+  /// 
+  /// ## Sample codeconst
+  /// 
+  /// ```dart
+  /// CodeInput(keyboardType: TextInputType.number)
+  /// ```
+  final TextInputType keyboardType;
+
+  /// A list of input formatters which can validate the text as it is being
+  /// typed.
+  /// 
+  /// If you specify this parameter, the default input formatters aren't used,
+  /// so make sure you really check for everything (like length of the input).
+  /// 
+  /// ## Sample code
+  /// 
+  /// An code input that displays a normal keyboard but only allows for
+  /// hexadecimal input:
+  /// 
+  /// ```dart
+  /// CodeInput(
+  ///   inputFormatters: [
+  ///     WhitelistingTextInputFormatter(RegExp('^[0-9a-fA-F]*\$'))
+  ///   ]
+  /// )
+  /// ```
+  final List<TextInputFormatter> inputFormatters;
+
+  /// A builder for the character entities.
+  /// 
+  /// See [CodeInputBuilders] for examples.
+  final CodeInputBuilder builder;
+
+  /// A callback for changes to the input.
+  final void Function(String value) onChanged;
+
+  /// A callback for when the input is filled.
+  final void Function(String value) onFilled;
+
+
+  /// A helping function that creates input formatters for a given length and
+  /// keyboardType.
+  static List<TextInputFormatter> _createInputFormatters(
+    int length,
+    TextInputType keyboardType
+  ) {
+    final formatters = <TextInputFormatter>[
+      LengthLimitingTextInputFormatter(length)
+    ];
+
+    // Add keyboard specific formatters.
+    // For example, a code input with a number keyboard type probably doesn't
+    // want to allow decimal separators or signs.
+    if (keyboardType == TextInputType.number) {
+      formatters.add(WhitelistingTextInputFormatter(RegExp('^[0-9]*\$')));
+    }
+
+    return formatters;
+  }
+
   @override
   _CodeInputState createState() => _CodeInputState();
 }
 
 class _CodeInputState extends State<CodeInput> {
-  CodeInputModel codeModel;
-  @override
-  void initState() {
-    super.initState();
-    codeModel = CodeInputModel(widget.length);
-  }
+  final node = FocusNode();
+  final controller = TextEditingController();
+  String get text => controller.text;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 300.0,
-      child: Row(
-        // crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: codeModel.inputs,
-      ),
-    );
-  }
-}
-
-class InputWidget extends StatefulWidget {
-  const InputWidget({
-    Key key,
-    this.index,
-    this.codeModel,
-  }) : super(key: key);
-
-  final int index;
-  final CodeInputModel codeModel;
-
-  @override
-  _InputWidgetState createState() {
-    return _InputWidgetState();
-  }
-}
-
-class _InputWidgetState extends State<InputWidget> {
-  String text;
-  @override
-  void initState() {
-    super.initState();
-    text = widget.codeModel.editingControllers[widget.index].text;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Flexible(
-      child: Padding(
-        padding: text.isNotEmpty
-            ? const EdgeInsets.all(0.0)
-            : const EdgeInsets.all(8.0),
-        child: Container(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(text.isNotEmpty ? 0.0 : 50.0),
-            border: Border.all(
-                color: text.isNotEmpty ? Colors.green : Colors.red,
-                width: text.isNotEmpty ? 1.0 : 1.5,
-                style: BorderStyle.solid),
-          ),
+    // We'll display the visual widget and a not shown EditableText for doing
+    // the actual work on top of each other.
+    return Stack(
+      children: <Widget>[
+        // This is the actual EditableText wrapped in a Container with zero
+        // dimensions.
+        Container(
+          width: 0.0,
+          height: 0.0,
           child: EditableText(
-            inputFormatters: [
-              LengthLimitingTextInputFormatter(1),
-            ],
-            keyboardType: TextInputType.number,
-            controller: widget.codeModel.editingControllers[widget.index],
-            textAlign: TextAlign.center,
-            focusNode: widget.codeModel.nodes[widget.index],
-            onChanged: (value) {
-              setState(() {
-                //to change the color when the edit is filled
-                text = value;
-              });
-              if (value.isEmpty) {
-                handleDelete(context);
-              } else {
-                handleCodeInput(context);
+            controller: controller,
+            focusNode: node,
+            inputFormatters: widget.inputFormatters,
+            keyboardType: widget.keyboardType,
+            style: TextStyle(), // Doesn't really matter.
+            cursorColor: Colors.black, // Doesn't really matter.
+            onChanged: (value) => setState(() {
+              widget.onChanged?.call(value);
+              if (value.length == widget.length) {
+                widget.onFilled?.call(value);
               }
-            },
-            style: TextStyle(fontSize: 30.0, color: Colors.black),
-            cursorColor: Colors.red,
-          ),
+            })
+          )
         ),
-      ),
+        // These are the actual character widgets. A transparent container lies
+        // right below the gesture detector, so all taps get collected, even
+        // the ones between the character entities.
+        GestureDetector(
+          onTap: () {
+            final focusScope = FocusScope.of(context);
+            focusScope.requestFocus(FocusNode());
+            Future.delayed(Duration.zero, () => focusScope.requestFocus(node));
+          },
+          child: Container(
+            color: Colors.transparent,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: List.generate(widget.length, (i) {
+                final hasFocus = controller.selection.start == i;
+                final char = i < text.length ? text[i] : '';
+                final characterEntity = widget.builder(hasFocus, char);
+
+                assert(characterEntity != null,
+                  'The builder for the character entity at position $i '
+                  'returned null. It did${hasFocus ? ' not' : ''} have the '
+                  'focus and the character passed to it was \'$char\'.'
+                );
+
+                return characterEntity;
+              }),
+            ),
+          )
+        ),
+      ]
+    );
+  }
+}
+
+
+
+/// An abstract class that provides some commonly-used builders for the
+/// character entities.
+/// 
+/// * [containerized]: A builder putting chars in an animated container.
+/// * [circle]: A builder putting chars in circles.
+/// * [rectangle]: A builder putting chars in rectangles.
+/// * [lightCircle]: A builder putting chars in light circles.
+/// * [darkCircle]: A builder putting chars in dark circles.
+/// * [lightRectangle]: A builer putting chars in light rectangles.
+/// * [darkRectangle]: A builder putting chars in dark rectanlges.
+abstract class CodeInputBuilders {
+
+  /// Builds the input inside an animated container.
+  static CodeInputBuilder containerized({
+    Duration animationDuration = const Duration(milliseconds: 50),
+    @required Size totalSize,
+    @required Size emptySize,
+    @required Size filledSize,
+    @required BoxDecoration emptyDecoration,
+    @required BoxDecoration filledDecoration,
+    @required TextStyle emptyTextStyle,
+    @required TextStyle filledTextStyle,
+  }) {
+    return (bool hasFocus, String char) => Container(
+      width: totalSize.width,
+      height: totalSize.height,
+      alignment: Alignment.center,
+      child: AnimatedContainer(
+        duration: Duration(milliseconds: 100),
+        decoration: char.isEmpty ? emptyDecoration : filledDecoration,
+        width: char.isEmpty ? emptySize.width: filledSize.width,
+        height: char.isEmpty ? emptySize.height : filledSize.height,
+        alignment: Alignment.center,
+        child: Text(char,
+          style: char.isEmpty ? emptyTextStyle : filledTextStyle
+        ),
+      )
     );
   }
 
-  void handleDelete(BuildContext context) {
-    int previousIndex = widget.index - 1;
-    var textController = widget.codeModel.editingControllers[widget.index];
-    if (textController.text.isNotEmpty) {}
+  /// Builds the input inside a circle.
+  static CodeInputBuilder circle({
+    double totalRadius = 30.0,
+    double emptyRadius = 10.0,
+    double filledRadius = 25.0,
+    @required Border border,
+    @required Color color,
+    @required TextStyle textStyle
+  }) {
+    final decoration = BoxDecoration(
+      shape: BoxShape.circle,
+      border: border,
+      color: color,
+    );
 
-    selectNode(context, previousIndex);
-    selectText(previousIndex);
-    // var selectAll = TextSelection(baseOffset: 1, extentOffset: 2);
-    // widget.editingControllers[previousIndex].selection = selectAll;
+    return containerized(
+      totalSize: Size.fromRadius(totalRadius),
+      emptySize: Size.fromRadius(emptyRadius),
+      filledSize: Size.fromRadius(filledRadius),
+      emptyDecoration: decoration,
+      filledDecoration: decoration,
+      emptyTextStyle: textStyle.copyWith(fontSize: 0.0),
+      filledTextStyle: textStyle
+    );
   }
 
-  void handleCodeInput(BuildContext context) {
-    if (widget.index < widget.codeModel.nodes.length - 1) {
-      int nextIndex = widget.index + 1;
-      selectNode(context, nextIndex);
-      selectText(nextIndex);
-    } else {
-      // if you want to loop the input
-      // FocusScope.of(context).requestFocus(widget.focusNode[0]);
-      // widget.editingControllers[0].selection =
-      //     TextSelection.collapsed(offset: 0);
-    }
+  /// Builds the input inside a rectangle.
+  static CodeInputBuilder rectangle({
+    Size totalSize = const Size(50.0, 60.0),
+    Size emptySize = const Size(20.0, 20.0),
+    Size filledSize = const Size(40.0, 60.0),
+    BorderRadius borderRadius = BorderRadius.zero,
+    @required Border border,
+    @required Color color,
+    @required TextStyle textStyle,
+  }) {
+    final decoration = BoxDecoration(
+      border: border,
+      borderRadius: borderRadius,
+      color: color,
+    );
+
+    return containerized(
+      totalSize: totalSize,
+      emptySize: emptySize,
+      filledSize: filledSize,
+      emptyDecoration: decoration,
+      filledDecoration: decoration,
+      emptyTextStyle: textStyle.copyWith(fontSize: 0.0),
+      filledTextStyle: textStyle
+    );
   }
 
-  void selectNode(BuildContext context, int index) {
-    FocusScope.of(context).requestFocus(widget.codeModel.nodes[index]);
+  /// Builds the input inside a light circle.
+  static CodeInputBuilder lightCircle({
+    double totalRadius = 30.0,
+    double emptyRadius = 10.0,
+    double filledRadius = 25.0,
+  }) {
+    return circle(
+      totalRadius: totalRadius,
+      emptyRadius: emptyRadius,
+      filledRadius: filledRadius,
+      border: Border.all(color: Colors.white, width: 2.0),
+      color: Colors.white10,
+      textStyle: TextStyle(
+        color: Colors.white,
+        fontSize: 20.0,
+        fontWeight: FontWeight.bold
+      )
+    );
   }
 
-  void selectText(int index) {
-    var selectAll = TextSelection(baseOffset: 0, extentOffset: 1);
-    widget.codeModel.editingControllers[index].selection = selectAll;
+  /// Builds the input inside a light circle.
+  static CodeInputBuilder darkCircle({
+    double totalRadius = 30.0,
+    double emptyRadius = 10.0,
+    double filledRadius = 25.0,
+  }) {
+    return circle(
+      totalRadius: totalRadius,
+      emptyRadius: emptyRadius,
+      filledRadius: filledRadius,
+      border: Border.all(color: Colors.black, width: 2.0),
+      color: Colors.black12,
+      textStyle: TextStyle(
+        color: Colors.black,
+        fontSize: 20.0,
+        fontWeight: FontWeight.bold
+      )
+    );
+  }
+
+  /// Builds the input inside a light rectangle.
+  static CodeInputBuilder lightRectangle({
+    Size totalSize = const Size(50.0, 60.0),
+    Size emptySize = const Size(20.0, 20.0),
+    Size filledSize = const Size(40.0, 60.0),
+    BorderRadius borderRadius = BorderRadius.zero,
+  }) {
+    return rectangle(
+      totalSize: totalSize,
+      emptySize: emptySize,
+      filledSize: filledSize,
+      borderRadius: borderRadius,
+      border: Border.all(color: Colors.white, width: 2.0),
+      color: Colors.white10,
+      textStyle: TextStyle(
+        color: Colors.white,
+        fontSize: 20.0,
+        fontWeight: FontWeight.bold
+      )
+    );
+  }
+
+  /// Builds the input inside a dark rectangle.
+  static CodeInputBuilder darkRectangle({
+    Size totalSize = const Size(50.0, 60.0),
+    Size emptySize = const Size(20.0, 20.0),
+    Size filledSize = const Size(40.0, 60.0),
+    BorderRadius borderRadius = BorderRadius.zero,
+  }) {
+    return rectangle(
+      totalSize: totalSize,
+      emptySize: emptySize,
+      filledSize: filledSize,
+      borderRadius: borderRadius,
+      border: Border.all(color: Colors.black, width: 2.0),
+      color: Colors.black12,
+      textStyle: TextStyle(
+        color: Colors.black,
+        fontSize: 20.0,
+        fontWeight: FontWeight.bold
+      )
+    );
   }
 }
 
-class CodeInputModel {
-  final nodes = List<FocusNode>();
-  final inputs = List<InputWidget>();
-  final editingControllers = List<TextEditingController>();
-  CodeInputModel(int lenght) {
-    for (var i = 0; i < lenght; i++) {
-      nodes.add(FocusNode());
-      editingControllers.add(TextEditingController(text: ""));
-    }
-    for (var i = 0; i < lenght; i++) {
-      inputs.add(InputWidget(
-        index: i,
-        codeModel: this,
-      ));
-    }
-  }
-}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,63 +7,63 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.31.2-alpha.2"
+    version: "0.32.4"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.3"
+    version: "1.5.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.6"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.6"
   csslib:
     dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.4"
+    version: "0.14.5"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,182 +80,189 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.12"
+    version: "0.1.4"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.7"
   html:
     dependency: transitive
     description:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.3+3"
   http:
     dependency: transitive
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+16"
+    version: "0.11.3+17"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2+1"
+    version: "0.3.3"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.1+1"
+  json_rpc_2:
+    dependency: transitive
+    description:
+      name: json_rpc_2
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.9"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.12"
+    version: "0.3.4"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+1"
+    version: "0.11.3+2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2+1"
+    version: "0.12.3+1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6"
+    version: "0.9.6+2"
   multi_server_socket:
     dependency: transitive
     description:
       name: multi_server_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.4"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   package_resolver:
     dependency: transitive
     description:
       name: package_resolver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.2"
   plugin:
     dependency: transitive
     description:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+2"
+    version: "0.2.0+3"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.4"
+    version: "1.3.6"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.29.0+1"
+    version: "2.0.0+1"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.3+3"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.7"
+    version: "0.2.8"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.2+4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -267,97 +274,104 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.1.5"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.5"
+    version: "0.10.7"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.9.3"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.6"
+    version: "1.6.8"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   test:
     dependency: transitive
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.37"
+    version: "1.3.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   utf:
     dependency: transitive
     description:
       name: utf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0+4"
+    version: "0.9.0+5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.8"
+  vm_service_client:
+    dependency: transitive
+    description:
+      name: vm_service_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.6"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+7"
+    version: "0.9.7+10"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.7"
+    version: "1.0.9"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.13"
+    version: "2.1.15"
 sdks:
-  dart: ">=2.0.0-dev.58.0 <=2.0.0-dev.58.0.flutter-f981f09760"
+  dart: ">=2.0.0-dev.68.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: code_input
 description: Flutter Code Input Widget
 version: 1.0.0
-author: Marcel Garus <marcel.garus@gmail.com> & Raouf Rahiche <rraouf30@gmail.com>
+author: Marcel Garus <marcel.garus@gmail.com>, Raouf Rahiche <rraouf30@gmail.com>
 homepage: https://github.com/Rahiche/flutter_code_input
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,8 @@
 name: code_input
 description: Flutter Code Input Widget
-version: 0.0.2
-author: Raouf Rahiche <rraouf30@gmail.com>
+version: 1.0.0
+author: Marcel Garus <marcel.garus@gmail.com> & Raouf Rahiche <rraouf30@gmail.com>
 homepage: https://github.com/Rahiche/flutter_code_input
-
 
 environment:
   sdk: ">=2.0.0-dev.58.0 <3.0.0"
@@ -15,40 +14,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-# For information on the generic Dart part of this file, see the
-# following page: https://www.dartlang.org/tools/pub/pubspec
-
-# The following section is specific to Flutter.
-flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.io/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.io/custom-fonts/#from-packages


### PR DESCRIPTION
Hey Rahiche,

I rewrote the code. Now, a custom builder is accepted which is called for every character.
Also, only one focus node and EditableText is used internally, so stuff like swiping on the space bar to change focus or holding the back button for deletion of everything works.
Just run the example app which is now included and you'll see how it works. [Here's a video of it.](https://photos.app.goo.gl/eNZdRLSWtT17z5nj8)

Because these are breaking changes, I bumped the version to 1.0.0, so library users won't break their app if they specified the version with `xxx^`.

I also added an example, cleaned the API reference and improved a lot of other stuff like the pubspec, readme and license.
The video of the widget still has to be updated tho.

Happy weekend
   Marcel